### PR TITLE
Substance painter publisher

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -462,7 +462,7 @@ class SubstancePainterEngine(Engine):
             raise tank.TankError(msg)
 
         if painter_version > painter_min_supported_version:
-            # show a warning that this version of Substance Painter isn't yet fully tested
+            # log a warning that this version of Substance Painter isn't yet fully tested
             # with Shotgun:
             msg = (
                 "The Shotgun Pipeline Toolkit has not yet been fully "
@@ -471,26 +471,6 @@ class SubstancePainterEngine(Engine):
                 "bugs or instability."
                 "\n\n" % (painter_version)
             )
-
-            # determine if we should show the compatibility warning dialog:
-            show_warning_dlg = self.has_ui and SHOW_COMP_DLG not in os.environ
-
-            if show_warning_dlg:
-                # make sure we only show it once per session
-                os.environ[SHOW_COMP_DLG] = "1"
-
-                # check against the compatibility_dialog_min_version
-                # setting
-                min_version_str = self.get_setting("compatibility_dialog_min_version")
-
-                min_version = to_new_version_system(min_version_str)
-                if painter_version < min_version:
-                    show_warning_dlg = False
-
-            if show_warning_dlg:
-                # Note, title is padded to try to ensure dialog isn't insanely
-                # narrow!
-                self.show_warning(msg)
 
             # always log the warning to the script editor:
             self.logger.warning(msg)

--- a/python/tk_substancepainter/application.py
+++ b/python/tk_substancepainter/application.py
@@ -270,7 +270,7 @@ class EngineClient(Client):
         result = self.send_and_receive("GET_MAP_EXPORT_INFORMATION")
         return result
 
-    def export_document_maps(self, destination):
+    def export_document_maps(self, preset, destination, format, mapInfo):
         # This is a trick to wait until the async process of
         # exporting textures finishes.
         self.__export_results = None
@@ -283,7 +283,11 @@ class EngineClient(Client):
         )
 
         self.log_debug("Starting map export...")
-        result = self.send_and_receive("EXPORT_DOCUMENT_MAPS", destination=destination)
+        self.send_and_receive("EXPORT_DOCUMENT_MAPS",
+                              preset=preset,
+                              destination=destination,
+                              format=format,
+                              mapInfo=mapInfo)
 
         while self.__export_results is None:
             self.log_debug("Waiting for maps to be exported ...")

--- a/resources/plugins/shotgun_bridge/main.qml
+++ b/resources/plugins/shotgun_bridge/main.qml
@@ -464,11 +464,8 @@ PainterPlugin
 
   function exportDocumentMaps(data)
   {
-    var export_preset = alg.mapexport.getProjectExportPreset();
-    var export_options = alg.mapexport.getProjectExportOptions();
-    var export_path = data.destination;
     server.sendCommand("EXPORT_STARTED", {});
-    var result = alg.mapexport.exportDocumentMaps(export_preset, export_path, export_options.fileFormat)
+    var result = alg.mapexport.exportDocumentMaps(data.preset, data.destination, data.format, data.mapInfo)
     server.sendCommand("EXPORT_FINISHED", {map_infos:result});
     return true;
   }


### PR DESCRIPTION
Changes for publishing textures:
- Update export_document_maps function to accept preset, file format, map info as parameters
- Do not show warning window if the current version of Substance Painter is lower than min supported version